### PR TITLE
Add travis-ci to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: "pip install -r requirements-dev.txt"
+script: nosetests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# image-scraper
+# image-scraper [![Build Status](https://travis-ci.org/nathanIL/image-scraper.svg)](https://travis-ci.org/nathanIL/image-scraper)
 Python script to scrap images 
 
 ### Developer's guide


### PR DESCRIPTION
Add travis-ci with nosetest to run our tests on each merged commit.
See the project's description for the tests / build status.
Currently it runs well only on python 2.7+, we can easily add support for python 3 as well.
